### PR TITLE
Update Android Studio and fix some PhotosListViewActivity bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,11 +11,17 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        buildConfigField 'String', 'BASE_APP_ID', '\"com.sparkwing.localview\"'
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'groovyx.grooid.groovy-android'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.sparkwing.localview"

--- a/app/src/main/java/com/sparkwing/localview/PhotoListManager.java
+++ b/app/src/main/java/com/sparkwing/localview/PhotoListManager.java
@@ -39,13 +39,13 @@ public class PhotoListManager implements LocationUpdaterListener, PhotoListFetch
 
     public void setPhotoListManagerListener(PhotoListManagerListener mPhotoListManagerListener) {
         Log.d(TAG, "setting photomanagerlistener");
+        this.mPhotoListFetched = false;
         this.mPhotoListManagerListener = mPhotoListManagerListener;
         this.mLocationUpdater.setupLocationService();
     }
 
     public PhotoListManager(Context context) {
         ((LocalviewApplication) context.getApplicationContext()).getLocationUpdaterComponent().inject(this);
-        this.mPhotoListFetched = false;
         if (Reachability.isConnected(context)) {
             this.mLocationUpdater.setLocationUpdaterListener(this);
         } else {

--- a/app/src/main/java/com/sparkwing/localview/PhotosListViewActivity.java
+++ b/app/src/main/java/com/sparkwing/localview/PhotosListViewActivity.java
@@ -28,6 +28,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     private static final String SAVE_PHOTO_LIST_KEY = "photo-list";
     private static final String PHOTO_LIST_STATE_KEY = "photo-list-state";
     private Parcelable mPhotoListState = null;
+    private Menu mMenu;
     private ViewSwitcher switcher;
     @Inject
     public RequestPermissionUtils requestPermissionUtils;
@@ -147,6 +148,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_photos_list_view, menu);
+        mMenu = menu;
         return true;
     }
 
@@ -161,6 +163,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
         if (id == R.id.action_refresh) {
             this.mPhotoListState = null;
             this.startPhotoListManager();
+            mMenu.findItem(R.id.action_refresh).setEnabled(false);
             return true;
         }
 
@@ -202,6 +205,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     @Override
     public void photoListManagerDidFinish(List<Photo> photoList) {
         this.mProgressBarSpinner.setVisibility(View.INVISIBLE);
+        mMenu.findItem(R.id.action_refresh).setEnabled(true);
         if (photoList.size() > 0) {
             this.mFlickrPhotoList = photoList;
             setupPhotoList();

--- a/app/src/main/java/com/sparkwing/localview/PhotosListViewActivity.java
+++ b/app/src/main/java/com/sparkwing/localview/PhotosListViewActivity.java
@@ -83,7 +83,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
         // in content do not change the layout size of the RecyclerView
         mPhotoRecyclerView.setHasFixedSize(true);
 
-        mLayoutManager = new GridLayoutManager(this, 4);
+        mLayoutManager = new GridLayoutManager(this, 5);
         mPhotoRecyclerView.setLayoutManager(mLayoutManager);
         PhotoListAdapter emptyPhotoListAdapter = new PhotoListAdapter(new ArrayList<Photo>());
         mPhotoRecyclerView.setAdapter(emptyPhotoListAdapter);

--- a/app/src/main/java/com/sparkwing/localview/PhotosListViewActivity.java
+++ b/app/src/main/java/com/sparkwing/localview/PhotosListViewActivity.java
@@ -27,6 +27,8 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     private static final String TAG = PhotosListViewActivity.class.getSimpleName();
     private static final String SAVE_PHOTO_LIST_KEY = "photo-list";
     private static final String PHOTO_LIST_STATE_KEY = "photo-list-state";
+    private static final int SWITCHER_PROGRESS_BAR = 0;
+    private static final int SWITCHER_RECYCLER_VIEW = 1;
     private Parcelable mPhotoListState = null;
     private Menu mMenu;
     private ViewSwitcher switcher;
@@ -37,7 +39,12 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
         @Override
         public void Granted(int requestCode) {
             Log.d(TAG, "permission granted");
-            startPhotoListManager();
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    startPhotoListManager();
+                }
+            });
         }
 
         @Override
@@ -77,7 +84,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
         Fresco.initialize(this);
         setContentView(R.layout.activity_photos_list_view);
         switcher = (ViewSwitcher) findViewById(R.id.ViewSwitcher);
-        switcher.showNext();
+        switcher.setDisplayedChild(SWITCHER_PROGRESS_BAR);
         mProgressBarSpinner = (ProgressBar)findViewById(R.id.progressBarSpinner);
         mPhotoRecyclerView = (RecyclerView) findViewById(R.id.listView);
         // use this setting to improve performance if you know that changes
@@ -104,7 +111,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     }
 
     protected void startPhotoListManager() {
-        switcher.setDisplayedChild(0);
+        switcher.setDisplayedChild(SWITCHER_PROGRESS_BAR);
         mProgressBarSpinner.setVisibility(View.VISIBLE);
         mPhotoListManager.setPhotoListManagerListener(this);
     }
@@ -128,7 +135,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     protected void onResume() {
         super.onResume();
         Log.wtf(TAG, "onResume");
-        this.mProgressBarSpinner.setVisibility(View.INVISIBLE);
+        this.mProgressBarSpinner.setVisibility(View.VISIBLE);
         if (this.mPhotoListState != null) {
             this.mPhotoRecyclerView.getLayoutManager().onRestoreInstanceState(this.mPhotoListState);
         }
@@ -197,7 +204,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
         PhotoListAdapter photoListAdapter = new PhotoListAdapter(this.mFlickrPhotoList);
         this.mPhotoRecyclerView.setAdapter(photoListAdapter);
         if (this.mFlickrPhotoList != null) {
-            switcher.showNext();
+            this.mProgressBarSpinner.setVisibility(View.VISIBLE);
             this.mPhotoRecyclerView.getLayoutManager().onRestoreInstanceState(this.mPhotoListState);
         }
     }
@@ -205,6 +212,7 @@ public class PhotosListViewActivity extends ActionBarActivity implements PhotoLi
     @Override
     public void photoListManagerDidFinish(List<Photo> photoList) {
         this.mProgressBarSpinner.setVisibility(View.INVISIBLE);
+        switcher.setDisplayedChild(SWITCHER_RECYCLER_VIEW);
         mMenu.findItem(R.id.action_refresh).setEnabled(true);
         if (photoList.size() > 0) {
             this.mFlickrPhotoList = photoList;

--- a/app/src/test/java/com/sparkwing/localview/LocationUpdaterTest.java
+++ b/app/src/test/java/com/sparkwing/localview/LocationUpdaterTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(LocalviewTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21, manifest = "../app/src/main/AndroidManifest.xml")
+@Config(constants = BuildConfig.class, packageName = BuildConfig.BASE_APP_ID, sdk = 21, manifest = "../app/src/main/AndroidManifest.xml")
 public class LocationUpdaterTest {
 
     LocationUpdater subject;

--- a/app/src/test/java/com/sparkwing/localview/PhotosListViewActivityTest.java
+++ b/app/src/test/java/com/sparkwing/localview/PhotosListViewActivityTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 
 @RunWith(LocalviewTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21, manifest = "../app/src/main/AndroidManifest.xml")
+@Config(constants = BuildConfig.class, packageName = BuildConfig.BASE_APP_ID, sdk = 21, manifest = "../app/src/main/AndroidManifest.xml")
 public class PhotosListViewActivityTest {
     PhotosListViewActivity subject;
     ActivityController<PhotosListViewActivity> activityController;

--- a/app/src/test/java/com/sparkwing/localview/PhotosListViewActivityTest.java
+++ b/app/src/test/java/com/sparkwing/localview/PhotosListViewActivityTest.java
@@ -53,7 +53,7 @@ public class PhotosListViewActivityTest {
         somePhoto.setSecret("shhh");
         flickrPhotoList = new ArrayList<Photo> (Arrays.asList(somePhoto));
         subject.setFlickrPhotoList(flickrPhotoList);
-        activityController.create().start();
+        activityController.create().start().visible();
         spy(subject);
     }
 

--- a/app/src/test/java/com/sparkwing/localview/RequestPermissionUtilsTest.java
+++ b/app/src/test/java/com/sparkwing/localview/RequestPermissionUtilsTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 
 
 @RunWith(LocalviewTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21, manifest = "../app/src/main/AndroidManifest.xml")
+@Config(constants = BuildConfig.class, packageName = BuildConfig.BASE_APP_ID, sdk = 21, manifest = "../app/src/main/AndroidManifest.xml")
 public class RequestPermissionUtilsTest {
 
     RequestPermissionUtils subject;

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'org.codehaus.groovy:gradle-groovy-android-plugin:0.3.6'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableAapt2 = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 08 15:26:17 EDT 2017
+#Sun Mar 04 08:35:34 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Android Studio v3.0.1 brought in some changes that broke the robolectric tests when gradle was upgraded to Android Studio's recommended version. 

We needed to turn off aapt2 and set includeAndroidResources to true in testOptions for unitTests.  

You will also need to set Working Directory to $MODULE_DIR$ to your Android JUnit
configuration for the tests when this changeset gets merged to master.